### PR TITLE
MNT: add layout to SL2K4Slits screen to fix typhos title issue

### DIFF
--- a/pcdsdevices/ui/SL2K4Slits.ui
+++ b/pcdsdevices/ui/SL2K4Slits.ui
@@ -6,599 +6,65 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>850</width>
-    <height>675</height>
+    <width>878</width>
+    <height>720</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <widget class="QLabel" name="top_lbl">
-   <property name="geometry">
-    <rect>
-     <x>210</x>
-     <y>60</y>
-     <width>21</width>
-     <height>20</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Top</string>
-   </property>
-   <property name="alignment">
-    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-   </property>
-  </widget>
-  <widget class="QLabel" name="north_label">
-   <property name="geometry">
-    <rect>
-     <x>1</x>
-     <y>250</y>
-     <width>41</width>
-     <height>20</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>North</string>
-   </property>
-   <property name="alignment">
-    <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-   </property>
-  </widget>
-  <widget class="PyDMScaleIndicator" name="top_blade">
-   <property name="geometry">
-    <rect>
-     <x>189</x>
-     <y>80</y>
-     <width>71</width>
-     <height>144</height>
-    </rect>
-   </property>
-   <property name="sizePolicy">
-    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-     <horstretch>0</horstretch>
-     <verstretch>0</verstretch>
-    </sizepolicy>
-   </property>
-   <property name="baseSize">
-    <size>
-     <width>0</width>
-     <height>0</height>
-    </size>
-   </property>
-   <property name="toolTip">
-    <string/>
-   </property>
-   <property name="precision" stdset="0">
-    <number>3</number>
-   </property>
-   <property name="precisionFromPV" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="channel" stdset="0">
-    <string>ca://${prefix}:MMS:TOP.RBV</string>
-   </property>
-   <property name="showValue" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="showLimits" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="showTicks" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="orientation" stdset="0">
-    <enum>Qt::Vertical</enum>
-   </property>
-   <property name="flipScale" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="invertedAppearance" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="barIndicator" stdset="0">
-    <bool>true</bool>
-   </property>
-   <property name="backgroundColor" stdset="0">
-    <color>
-     <red>0</red>
-     <green>0</green>
-     <blue>0</blue>
-    </color>
-   </property>
-   <property name="indicatorColor" stdset="0">
-    <color>
-     <red>255</red>
-     <green>170</green>
-     <blue>0</blue>
-    </color>
-   </property>
-   <property name="scaleHeight" stdset="0">
-    <number>80</number>
-   </property>
-   <property name="valuePosition" stdset="0">
-    <enum>Qt::TopEdge</enum>
-   </property>
-   <property name="originAtZero" stdset="0">
-    <bool>true</bool>
-   </property>
-   <property name="limitsFromChannel" stdset="0">
-    <bool>true</bool>
-   </property>
-   <property name="userLowerLimit" stdset="0">
-    <double>0.000000000000000</double>
-   </property>
-   <property name="userUpperLimit" stdset="0">
-    <double>0.000000000000000</double>
-   </property>
-  </widget>
-  <widget class="PyDMScaleIndicator" name="bottom_blade">
-   <property name="geometry">
-    <rect>
-     <x>189</x>
-     <y>290</y>
-     <width>71</width>
-     <height>144</height>
-    </rect>
-   </property>
-   <property name="sizePolicy">
-    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-     <horstretch>0</horstretch>
-     <verstretch>0</verstretch>
-    </sizepolicy>
-   </property>
-   <property name="toolTip">
-    <string/>
-   </property>
-   <property name="precision" stdset="0">
-    <number>3</number>
-   </property>
-   <property name="precisionFromPV" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="channel" stdset="0">
-    <string>ca://${prefix}:MMS:BOTTOM.RBV</string>
-   </property>
-   <property name="showValue" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="showLimits" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="showTicks" stdset="0">
-    <bool>true</bool>
-   </property>
-   <property name="orientation" stdset="0">
-    <enum>Qt::Vertical</enum>
-   </property>
-   <property name="flipScale" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="invertedAppearance" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="barIndicator" stdset="0">
-    <bool>true</bool>
-   </property>
-   <property name="backgroundColor" stdset="0">
-    <color>
-     <red>255</red>
-     <green>170</green>
-     <blue>0</blue>
-    </color>
-   </property>
-   <property name="indicatorColor" stdset="0">
-    <color>
-     <red>0</red>
-     <green>0</green>
-     <blue>0</blue>
-    </color>
-   </property>
-   <property name="scaleHeight" stdset="0">
-    <number>80</number>
-   </property>
-   <property name="valuePosition" stdset="0">
-    <enum>Qt::TopEdge</enum>
-   </property>
-   <property name="originAtZero" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="limitsFromChannel" stdset="0">
-    <bool>true</bool>
-   </property>
-   <property name="userLowerLimit" stdset="0">
-    <double>0.000000000000000</double>
-   </property>
-   <property name="userUpperLimit" stdset="0">
-    <double>0.000000000000000</double>
-   </property>
-  </widget>
-  <widget class="QLabel" name="bottom_label">
-   <property name="geometry">
-    <rect>
-     <x>199</x>
-     <y>440</y>
-     <width>47</width>
-     <height>14</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>Bottom</string>
-   </property>
-  </widget>
-  <widget class="PyDMScaleIndicator" name="north_blade">
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
-   <property name="geometry">
-    <rect>
-     <x>50</x>
-     <y>220</y>
-     <width>141</width>
-     <height>71</height>
-    </rect>
-   </property>
-   <property name="sizePolicy">
-    <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-     <horstretch>0</horstretch>
-     <verstretch>0</verstretch>
-    </sizepolicy>
-   </property>
-   <property name="toolTip">
-    <string/>
-   </property>
-   <property name="lineWidth">
-    <number>1</number>
-   </property>
-   <property name="midLineWidth">
-    <number>0</number>
-   </property>
-   <property name="precision" stdset="0">
-    <number>3</number>
-   </property>
-   <property name="precisionFromPV" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="channel" stdset="0">
-    <string>ca://${prefix}:MMS:NORTH.RBV</string>
-   </property>
-   <property name="showValue" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="showLimits" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="showTicks" stdset="0">
-    <bool>true</bool>
-   </property>
-   <property name="orientation" stdset="0">
-    <enum>Qt::Horizontal</enum>
-   </property>
-   <property name="flipScale" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="invertedAppearance" stdset="0">
-    <bool>true</bool>
-   </property>
-   <property name="barIndicator" stdset="0">
-    <bool>true</bool>
-   </property>
-   <property name="backgroundColor" stdset="0">
-    <color>
-     <red>0</red>
-     <green>0</green>
-     <blue>0</blue>
-    </color>
-   </property>
-   <property name="indicatorColor" stdset="0">
-    <color>
-     <red>255</red>
-     <green>170</green>
-     <blue>0</blue>
-    </color>
-   </property>
-   <property name="scaleHeight" stdset="0">
-    <number>80</number>
-   </property>
-   <property name="originAtZero" stdset="0">
-    <bool>true</bool>
-   </property>
-   <property name="limitsFromChannel" stdset="0">
-    <bool>true</bool>
-   </property>
-   <property name="userLowerLimit" stdset="0">
-    <double>0.000000000000000</double>
-   </property>
-   <property name="userUpperLimit" stdset="0">
-    <double>0.000000000000000</double>
-   </property>
-  </widget>
-  <widget class="PyDMScaleIndicator" name="south_blade">
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
-   <property name="geometry">
-    <rect>
-     <x>260</x>
-     <y>220</y>
-     <width>141</width>
-     <height>71</height>
-    </rect>
-   </property>
-   <property name="toolTip">
-    <string/>
-   </property>
-   <property name="precision" stdset="0">
-    <number>3</number>
-   </property>
-   <property name="precisionFromPV" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="alarmSensitiveBorder" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="channel" stdset="0">
-    <string>ca://${prefix}:MMS:SOUTH.RBV</string>
-   </property>
-   <property name="showValue" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="showLimits" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="showTicks" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="orientation" stdset="0">
-    <enum>Qt::Horizontal</enum>
-   </property>
-   <property name="flipScale" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="invertedAppearance" stdset="0">
-    <bool>true</bool>
-   </property>
-   <property name="barIndicator" stdset="0">
-    <bool>true</bool>
-   </property>
-   <property name="backgroundColor" stdset="0">
-    <color>
-     <red>255</red>
-     <green>170</green>
-     <blue>0</blue>
-    </color>
-   </property>
-   <property name="indicatorColor" stdset="0">
-    <color>
-     <red>0</red>
-     <green>0</green>
-     <blue>0</blue>
-    </color>
-   </property>
-   <property name="scaleHeight" stdset="0">
-    <number>80</number>
-   </property>
-   <property name="valuePosition" stdset="0">
-    <enum>Qt::TopEdge</enum>
-   </property>
-   <property name="limitsFromChannel" stdset="0">
-    <bool>true</bool>
-   </property>
-   <property name="userLowerLimit" stdset="0">
-    <double>0.000000000000000</double>
-   </property>
-   <property name="userUpperLimit" stdset="0">
-    <double>0.000000000000000</double>
-   </property>
-  </widget>
-  <widget class="QLabel" name="south_label">
-   <property name="geometry">
-    <rect>
-     <x>410</x>
-     <y>250</y>
-     <width>41</width>
-     <height>16</height>
-    </rect>
-   </property>
-   <property name="text">
-    <string>South</string>
-   </property>
-  </widget>
-  <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
-   <property name="geometry">
-    <rect>
-     <x>0</x>
-     <y>-10</y>
-     <width>850</width>
-     <height>75</height>
-    </rect>
-   </property>
-   <property name="toolTip">
-    <string/>
-   </property>
-   <property name="underline_midLineWidth" stdset="0">
-    <number>-4</number>
-   </property>
-  </widget>
-  <widget class="QWidget" name="layoutWidget">
-   <property name="geometry">
-    <rect>
-     <x>0</x>
-     <y>480</y>
-     <width>851</width>
-     <height>54</height>
-    </rect>
-   </property>
-   <layout class="QGridLayout" name="gridLayout">
-    <property name="topMargin">
-     <number>0</number>
-    </property>
-    <item row="0" column="2">
-     <widget class="PyDMLineEdit" name="PyDMLineEdit_23">
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="TyphosDisplayTitle" name="TyphosDisplayTitle">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="underline_midLineWidth" stdset="0">
+      <number>-4</number>
+     </property>
+    </widget>
+   </item>
+   <item alignment="Qt::AlignHCenter">
+    <widget class="QFrame" name="frame">
+     <property name="minimumSize">
+      <size>
+       <width>860</width>
+       <height>405</height>
+      </size>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>860</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::StyledPanel</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <widget class="PyDMScaleIndicator" name="top_blade">
+      <property name="geometry">
+       <rect>
+        <x>190</x>
+        <y>20</y>
+        <width>71</width>
+        <height>144</height>
+       </rect>
+      </property>
       <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
         <horstretch>0</horstretch>
         <verstretch>0</verstretch>
        </sizepolicy>
       </property>
-      <property name="maximumSize">
+      <property name="baseSize">
        <size>
-        <width>60</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>3</number>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:XCEN_REQ</string>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="2">
-     <widget class="PyDMLineEdit" name="PyDMLineEdit_24">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>60</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>3</number>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:XWID_REQ</string>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="0">
-     <widget class="QLabel" name="label_10">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>80</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Gap (mm)</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignCenter</set>
-      </property>
-      <property name="margin">
-       <number>0</number>
-      </property>
-      <property name="indent">
-       <number>5</number>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="1">
-     <widget class="PyDMLabel" name="PyDMLabel_47">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>75</width>
+        <width>0</width>
         <height>0</height>
        </size>
       </property>
-      <property name="maximumSize">
-       <size>
-        <width>60</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="whatsThis">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>3</number>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:ACTUAL_XCENTER_RBV</string>
-      </property>
-      <property name="displayFormat" stdset="0">
-       <enum>PyDMLabel::Decimal</enum>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="0">
-     <widget class="QLabel" name="label_9">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>80</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Center (mm)</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignCenter</set>
-      </property>
-      <property name="margin">
-       <number>0</number>
-      </property>
-      <property name="indent">
-       <number>5</number>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="5">
-     <widget class="PyDMLineEdit" name="PyDMLineEdit_7">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>60</width>
-        <height>16777215</height>
-       </size>
-      </property>
       <property name="toolTip">
        <string/>
       </property>
@@ -607,860 +73,1397 @@
       </property>
       <property name="precisionFromPV" stdset="0">
        <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:YCEN_REQ</string>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="5">
-     <widget class="PyDMLineEdit" name="PyDMLineEdit_8">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>60</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>3</number>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:YWID_REQ</string>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="4">
-     <widget class="PyDMLabel" name="PyDMLabel_46">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>75</width>
-        <height>0</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>60</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="whatsThis">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>3</number>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:ACTUAL_YWIDTH_RBV</string>
-      </property>
-      <property name="displayFormat" stdset="0">
-       <enum>PyDMLabel::Decimal</enum>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="1">
-     <widget class="PyDMLabel" name="PyDMLabel_48">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>75</width>
-        <height>0</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>60</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="whatsThis">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>3</number>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:ACTUAL_XWIDTH_RBV</string>
-      </property>
-      <property name="displayFormat" stdset="0">
-       <enum>PyDMLabel::Decimal</enum>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="4">
-     <widget class="PyDMLabel" name="PyDMLabel_45">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="minimumSize">
-       <size>
-        <width>75</width>
-        <height>0</height>
-       </size>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>60</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="whatsThis">
-       <string/>
-      </property>
-      <property name="precision" stdset="0">
-       <number>3</number>
-      </property>
-      <property name="precisionFromPV" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:ACTUAL_YCENTER_RBV</string>
-      </property>
-      <property name="displayFormat" stdset="0">
-       <enum>PyDMLabel::Decimal</enum>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="3">
-     <widget class="QLabel" name="label_11">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>80</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Center (mm)</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignCenter</set>
-      </property>
-      <property name="margin">
-       <number>0</number>
-      </property>
-      <property name="indent">
-       <number>5</number>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="3">
-     <widget class="QLabel" name="label_12">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>80</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="text">
-       <string>Gap (mm)</string>
-      </property>
-      <property name="alignment">
-       <set>Qt::AlignCenter</set>
-      </property>
-      <property name="margin">
-       <number>0</number>
-      </property>
-      <property name="indent">
-       <number>5</number>
-      </property>
-     </widget>
-    </item>
-   </layout>
-  </widget>
-  <widget class="Line" name="line">
-   <property name="geometry">
-    <rect>
-     <x>0</x>
-     <y>470</y>
-     <width>850</width>
-     <height>3</height>
-    </rect>
-   </property>
-   <property name="lineWidth">
-    <number>1</number>
-   </property>
-   <property name="orientation">
-    <enum>Qt::Horizontal</enum>
-   </property>
-  </widget>
-  <widget class="QLabel" name="label_13">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>540</y>
-     <width>850</width>
-     <height>16</height>
-    </rect>
-   </property>
-   <property name="font">
-    <font>
-     <italic>false</italic>
-    </font>
-   </property>
-   <property name="text">
-    <string>Individual Motor Control</string>
-   </property>
-   <property name="alignment">
-    <set>Qt::AlignCenter</set>
-   </property>
-  </widget>
-  <widget class="QWidget" name="layoutWidget_2">
-   <property name="geometry">
-    <rect>
-     <x>0</x>
-     <y>560</y>
-     <width>851</width>
-     <height>112</height>
-    </rect>
-   </property>
-   <layout class="QGridLayout" name="gridLayout_2">
-    <property name="topMargin">
-     <number>0</number>
-    </property>
-    <item row="2" column="1">
-     <widget class="PyDMByteIndicator" name="PyDMByteIndicator_4">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:MMS:NORTH.LLS</string>
-      </property>
-      <property name="onColor" stdset="0">
-       <color>
-        <red>255</red>
-        <green>255</green>
-        <blue>0</blue>
-       </color>
-      </property>
-      <property name="showLabels" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="circles" stdset="0">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="1">
-     <widget class="PyDMByteIndicator" name="PyDMByteIndicator">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:MMS:TOP.LLS</string>
-      </property>
-      <property name="onColor" stdset="0">
-       <color>
-        <red>255</red>
-        <green>255</green>
-        <blue>0</blue>
-       </color>
-      </property>
-      <property name="showLabels" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="circles" stdset="0">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="2">
-     <widget class="PyDMLabel" name="PyDMLabel_2">
-      <property name="maximumSize">
-       <size>
-        <width>80</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:MMS:BOTTOM.RBV</string>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="3">
-     <widget class="PyDMByteIndicator" name="PyDMByteIndicator_2">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:MMS:TOP.HLS</string>
-      </property>
-      <property name="onColor" stdset="0">
-       <color>
-        <red>255</red>
-        <green>255</green>
-        <blue>0</blue>
-       </color>
-      </property>
-      <property name="showLabels" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="circles" stdset="0">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="0">
-     <widget class="QLabel" name="label_4">
-      <property name="text">
-       <string>BOTTOM</string>
-      </property>
-      <property name="indent">
-       <number>5</number>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="3">
-     <widget class="PyDMByteIndicator" name="PyDMByteIndicator_8">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:MMS:SOUTH.HLS</string>
-      </property>
-      <property name="onColor" stdset="0">
-       <color>
-        <red>255</red>
-        <green>255</green>
-        <blue>0</blue>
-       </color>
-      </property>
-      <property name="showLabels" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="circles" stdset="0">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="6">
-     <widget class="PyDMShellCommand" name="PyDMShellCommand_2">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="text">
-       <string>Expert</string>
-      </property>
-      <property name="commands" stdset="0">
-       <stringlist>
-        <string>typhos &quot;pcdsdevices.epics_motor.BeckhoffAxis[{'prefix':'${prefix}:MMS:BOTTOM','name':'${name}_bottom'}]&quot;</string>
-       </stringlist>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="2">
-     <widget class="PyDMLabel" name="PyDMLabel_4">
-      <property name="maximumSize">
-       <size>
-        <width>80</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:MMS:SOUTH.RBV</string>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="4">
-     <widget class="PyDMLineEdit" name="PyDMLineEdit_3">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>80</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:MMS:NORTH.VAL</string>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="0">
-     <widget class="QLabel" name="label_3">
-      <property name="text">
-       <string>NORTH</string>
-      </property>
-      <property name="indent">
-       <number>5</number>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="4">
-     <widget class="PyDMLineEdit" name="PyDMLineEdit">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>80</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:MMS:TOP.VAL</string>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="2">
-     <widget class="PyDMLabel" name="PyDMLabel_3">
-      <property name="maximumSize">
-       <size>
-        <width>80</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:MMS:NORTH.RBV</string>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="5">
-     <widget class="PyDMPushButton" name="PyDMPushButton_4">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">background-color: red;</string>
-      </property>
-      <property name="text">
-       <string>Stop</string>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:MMS:SOUTH.STOP</string>
-      </property>
-      <property name="pressValue" stdset="0">
-       <string>1</string>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="1">
-     <widget class="PyDMByteIndicator" name="PyDMByteIndicator_5">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:MMS:SOUTH.LLS</string>
-      </property>
-      <property name="onColor" stdset="0">
-       <color>
-        <red>255</red>
-        <green>255</green>
-        <blue>0</blue>
-       </color>
-      </property>
-      <property name="showLabels" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="circles" stdset="0">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="4">
-     <widget class="PyDMLineEdit" name="PyDMLineEdit_2">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="maximumSize">
-       <size>
-        <width>80</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:MMS:BOTTOM.VAL</string>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="2">
-     <widget class="PyDMLabel" name="PyDMLabel">
-      <property name="maximumSize">
-       <size>
-        <width>80</width>
-        <height>16777215</height>
-       </size>
-      </property>
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="showUnits" stdset="0">
-       <bool>true</bool>
       </property>
       <property name="channel" stdset="0">
        <string>ca://${prefix}:MMS:TOP.RBV</string>
       </property>
+      <property name="showValue" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="invertedAppearance" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="valuePosition" stdset="0">
+       <enum>Qt::TopEdge</enum>
+      </property>
+      <property name="originAtZero" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
      </widget>
-    </item>
-    <item row="3" column="4">
-     <widget class="PyDMLineEdit" name="PyDMLineEdit_4">
+     <widget class="PyDMImageView" name="PyDMImageView">
+      <property name="geometry">
+       <rect>
+        <x>451</x>
+        <y>0</y>
+        <width>400</width>
+        <height>400</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="colorMap" stdset="0">
+       <enum>PyDMImageView::Jet</enum>
+      </property>
+      <property name="autoDownsample" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="normalizeData" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="dimensionOrder" stdset="0">
+       <enum>PyDMImageView::WidthFirst</enum>
+      </property>
+      <property name="imageChannel" stdset="0">
+       <string>pva://${cam}:${data_source}:Pva:Image</string>
+      </property>
+     </widget>
+     <widget class="PyDMDrawingRectangle" name="PyDMDrawingRectangle">
+      <property name="geometry">
+       <rect>
+        <x>191</x>
+        <y>170</y>
+        <width>71</width>
+        <height>61</height>
+       </rect>
+      </property>
+      <property name="toolTip">
+       <string/>
+      </property>
+      <property name="brush" stdset="0">
+       <brush brushstyle="CrossPattern">
+        <color alpha="255">
+         <red>255</red>
+         <green>255</green>
+         <blue>255</blue>
+        </color>
+       </brush>
+      </property>
+      <property name="penStyle" stdset="0">
+       <enum>Qt::SolidLine</enum>
+      </property>
+      <property name="penColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>255</green>
+        <blue>255</blue>
+       </color>
+      </property>
+     </widget>
+     <widget class="QLabel" name="top_lbl">
+      <property name="geometry">
+       <rect>
+        <x>211</x>
+        <y>0</y>
+        <width>21</width>
+        <height>20</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Top</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+     <widget class="QLabel" name="bottom_label">
+      <property name="geometry">
+       <rect>
+        <x>200</x>
+        <y>380</y>
+        <width>47</width>
+        <height>14</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Bottom</string>
+      </property>
+     </widget>
+     <widget class="PyDMScaleIndicator" name="north_blade">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>51</x>
+        <y>160</y>
+        <width>141</width>
+        <height>71</height>
+       </rect>
+      </property>
       <property name="sizePolicy">
-       <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
         <horstretch>0</horstretch>
         <verstretch>0</verstretch>
        </sizepolicy>
       </property>
-      <property name="maximumSize">
-       <size>
-        <width>80</width>
-        <height>16777215</height>
-       </size>
-      </property>
       <property name="toolTip">
        <string/>
+      </property>
+      <property name="lineWidth">
+       <number>1</number>
+      </property>
+      <property name="midLineWidth">
+       <number>0</number>
+      </property>
+      <property name="precision" stdset="0">
+       <number>3</number>
+      </property>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
       </property>
       <property name="channel" stdset="0">
-       <string>ca://${prefix}:MMS:SOUTH.VAL</string>
+       <string>ca://${prefix}:MMS:NORTH.RBV</string>
       </property>
-     </widget>
-    </item>
-    <item row="0" column="0">
-     <widget class="QLabel" name="label">
-      <property name="text">
-       <string>TOP</string>
+      <property name="showValue" stdset="0">
+       <bool>false</bool>
       </property>
-      <property name="indent">
-       <number>5</number>
+      <property name="showLimits" stdset="0">
+       <bool>false</bool>
       </property>
-     </widget>
-    </item>
-    <item row="2" column="6">
-     <widget class="PyDMShellCommand" name="PyDMShellCommand_3">
-      <property name="toolTip">
-       <string/>
+      <property name="showTicks" stdset="0">
+       <bool>true</bool>
       </property>
-      <property name="text">
-       <string>Expert</string>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Horizontal</enum>
       </property>
-      <property name="commands" stdset="0">
-       <stringlist>
-        <string>typhos &quot;pcdsdevices.epics_motor.BeckhoffAxis[{'prefix':'${prefix}:MMS:NORTH','name':'${name}_north'}]&quot;</string>
-       </stringlist>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
       </property>
-     </widget>
-    </item>
-    <item row="1" column="1">
-     <widget class="PyDMByteIndicator" name="PyDMByteIndicator_3">
-      <property name="toolTip">
-       <string/>
+      <property name="invertedAppearance" stdset="0">
+       <bool>true</bool>
       </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:MMS:BOTTOM.LLS</string>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
       </property>
-      <property name="onColor" stdset="0">
+      <property name="backgroundColor" stdset="0">
        <color>
-        <red>255</red>
-        <green>255</green>
+        <red>0</red>
+        <green>0</green>
         <blue>0</blue>
        </color>
       </property>
-      <property name="showLabels" stdset="0">
-       <bool>false</bool>
-      </property>
-      <property name="circles" stdset="0">
-       <bool>true</bool>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="6">
-     <widget class="PyDMShellCommand" name="PyDMShellCommand">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="text">
-       <string>Expert</string>
-      </property>
-      <property name="showIcon" stdset="0">
-       <bool>true</bool>
-      </property>
-      <property name="commands" stdset="0">
-       <stringlist>
-        <string>typhos &quot;pcdsdevices.epics_motor.BeckhoffAxis[{'prefix':'${prefix}:MMS:TOP','name':'${name}_top'}]&quot;</string>
-       </stringlist>
-      </property>
-     </widget>
-    </item>
-    <item row="3" column="6">
-     <widget class="PyDMShellCommand" name="PyDMShellCommand_4">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="text">
-       <string>Expert</string>
-      </property>
-      <property name="commands" stdset="0">
-       <stringlist>
-        <string>typhos &quot;pcdsdevices.epics_motor.BeckhoffAxis[{'prefix':'${prefix}:MMS:SOUTH','name':'${name}_south'}]&quot;</string>
-       </stringlist>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="5">
-     <widget class="PyDMPushButton" name="PyDMPushButton">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">background-color: red;</string>
-      </property>
-      <property name="text">
-       <string>Stop</string>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:MMS:TOP.STOP</string>
-      </property>
-      <property name="pressValue" stdset="0">
-       <string>1</string>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="3">
-     <widget class="PyDMByteIndicator" name="PyDMByteIndicator_6">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:MMS:BOTTOM.HLS</string>
-      </property>
-      <property name="onColor" stdset="0">
+      <property name="indicatorColor" stdset="0">
        <color>
         <red>255</red>
-        <green>255</green>
+        <green>170</green>
         <blue>0</blue>
        </color>
       </property>
-      <property name="showLabels" stdset="0">
-       <bool>false</bool>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
       </property>
-      <property name="circles" stdset="0">
+      <property name="originAtZero" stdset="0">
        <bool>true</bool>
       </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
      </widget>
-    </item>
-    <item row="3" column="0">
-     <widget class="QLabel" name="label_2">
+     <widget class="QLabel" name="south_label">
+      <property name="geometry">
+       <rect>
+        <x>411</x>
+        <y>190</y>
+        <width>41</width>
+        <height>16</height>
+       </rect>
+      </property>
       <property name="text">
-       <string>SOUTH</string>
-      </property>
-      <property name="indent">
-       <number>5</number>
+       <string>South</string>
       </property>
      </widget>
-    </item>
-    <item row="2" column="3">
-     <widget class="PyDMByteIndicator" name="PyDMByteIndicator_7">
+     <widget class="PyDMScaleIndicator" name="south_blade">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="geometry">
+       <rect>
+        <x>261</x>
+        <y>160</y>
+        <width>141</width>
+        <height>71</height>
+       </rect>
+      </property>
       <property name="toolTip">
        <string/>
       </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:MMS:NORTH.HLS</string>
+      <property name="precision" stdset="0">
+       <number>3</number>
       </property>
-      <property name="onColor" stdset="0">
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="alarmSensitiveBorder" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="channel" stdset="0">
+       <string>ca://${prefix}:MMS:SOUTH.RBV</string>
+      </property>
+      <property name="showValue" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="invertedAppearance" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
        <color>
         <red>255</red>
-        <green>255</green>
+        <green>170</green>
         <blue>0</blue>
        </color>
       </property>
-      <property name="showLabels" stdset="0">
-       <bool>false</bool>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
       </property>
-      <property name="circles" stdset="0">
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="valuePosition" stdset="0">
+       <enum>Qt::TopEdge</enum>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
        <bool>true</bool>
       </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
      </widget>
-    </item>
-    <item row="1" column="5">
-     <widget class="PyDMPushButton" name="PyDMPushButton_2">
+     <widget class="PyDMScaleIndicator" name="bottom_blade">
+      <property name="geometry">
+       <rect>
+        <x>190</x>
+        <y>230</y>
+        <width>71</width>
+        <height>144</height>
+       </rect>
+      </property>
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+        <horstretch>0</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
       <property name="toolTip">
        <string/>
       </property>
-      <property name="styleSheet">
-       <string notr="true">background-color: red;</string>
+      <property name="precision" stdset="0">
+       <number>3</number>
       </property>
-      <property name="text">
-       <string>Stop</string>
-      </property>
-      <property name="channel" stdset="0">
-       <string>ca://${prefix}:MMS:BOTTOM.STOP</string>
-      </property>
-      <property name="pressValue" stdset="0">
-       <string>1</string>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="5">
-     <widget class="PyDMPushButton" name="PyDMPushButton_3">
-      <property name="toolTip">
-       <string/>
-      </property>
-      <property name="styleSheet">
-       <string notr="true">background-color: red;</string>
-      </property>
-      <property name="text">
-       <string>Stop</string>
+      <property name="precisionFromPV" stdset="0">
+       <bool>false</bool>
       </property>
       <property name="channel" stdset="0">
-       <string>ca://${prefix}:MMS:NORTH.STOP</string>
+       <string>ca://${prefix}:MMS:BOTTOM.RBV</string>
       </property>
-      <property name="pressValue" stdset="0">
-       <string>1</string>
+      <property name="showValue" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showLimits" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="showTicks" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="orientation" stdset="0">
+       <enum>Qt::Vertical</enum>
+      </property>
+      <property name="flipScale" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="invertedAppearance" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="barIndicator" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="backgroundColor" stdset="0">
+       <color>
+        <red>255</red>
+        <green>170</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="indicatorColor" stdset="0">
+       <color>
+        <red>0</red>
+        <green>0</green>
+        <blue>0</blue>
+       </color>
+      </property>
+      <property name="scaleHeight" stdset="0">
+       <number>80</number>
+      </property>
+      <property name="valuePosition" stdset="0">
+       <enum>Qt::TopEdge</enum>
+      </property>
+      <property name="originAtZero" stdset="0">
+       <bool>false</bool>
+      </property>
+      <property name="limitsFromChannel" stdset="0">
+       <bool>true</bool>
+      </property>
+      <property name="userLowerLimit" stdset="0">
+       <double>0.000000000000000</double>
+      </property>
+      <property name="userUpperLimit" stdset="0">
+       <double>0.000000000000000</double>
       </property>
      </widget>
-    </item>
-   </layout>
-  </widget>
-  <widget class="PyDMImageView" name="PyDMImageView">
-   <property name="geometry">
-    <rect>
-     <x>450</x>
-     <y>60</y>
-     <width>400</width>
-     <height>400</height>
-    </rect>
-   </property>
-   <property name="toolTip">
-    <string/>
-   </property>
-   <property name="alarmSensitiveBorder" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="colorMap" stdset="0">
-    <enum>PyDMImageView::Jet</enum>
-   </property>
-   <property name="autoDownsample" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="normalizeData" stdset="0">
-    <bool>false</bool>
-   </property>
-   <property name="dimensionOrder" stdset="0">
-    <enum>PyDMImageView::WidthFirst</enum>
-   </property>
-   <property name="imageChannel" stdset="0">
-    <string>pva://${cam}:${data_source}:Pva:Image</string>
-   </property>
-  </widget>
-  <widget class="PyDMDrawingRectangle" name="PyDMDrawingRectangle">
-   <property name="geometry">
-    <rect>
-     <x>190</x>
-     <y>230</y>
-     <width>71</width>
-     <height>61</height>
-    </rect>
-   </property>
-   <property name="toolTip">
-    <string/>
-   </property>
-   <property name="brush" stdset="0">
-    <brush brushstyle="CrossPattern">
-     <color alpha="255">
-      <red>255</red>
-      <green>255</green>
-      <blue>255</blue>
-     </color>
-    </brush>
-   </property>
-   <property name="penStyle" stdset="0">
-    <enum>Qt::SolidLine</enum>
-   </property>
-   <property name="penColor" stdset="0">
-    <color>
-     <red>255</red>
-     <green>255</green>
-     <blue>255</blue>
-    </color>
-   </property>
-  </widget>
+     <widget class="QLabel" name="north_label">
+      <property name="geometry">
+       <rect>
+        <x>2</x>
+        <y>190</y>
+        <width>41</width>
+        <height>20</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>North</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+      </property>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="Line" name="line">
+     <property name="lineWidth">
+      <number>1</number>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item row="0" column="2">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_23">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:XCEN_REQ</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_24">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:XWID_REQ</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_10">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Gap (mm)</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="PyDMLabel" name="PyDMLabel_47">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:ACTUAL_XCENTER_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_9">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Center (mm)</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="5">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_7">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YCEN_REQ</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="5">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_8">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:YWID_REQ</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="4">
+      <widget class="PyDMLabel" name="PyDMLabel_46">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:ACTUAL_YWIDTH_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="PyDMLabel" name="PyDMLabel_48">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:ACTUAL_XWIDTH_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="4">
+      <widget class="PyDMLabel" name="PyDMLabel_45">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>75</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>60</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="precision" stdset="0">
+        <number>3</number>
+       </property>
+       <property name="precisionFromPV" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:ACTUAL_YCENTER_RBV</string>
+       </property>
+       <property name="displayFormat" stdset="0">
+        <enum>PyDMLabel::Decimal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
+      <widget class="QLabel" name="label_11">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Center (mm)</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="QLabel" name="label_12">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Gap (mm)</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLabel" name="label_13">
+     <property name="font">
+      <font>
+       <italic>false</italic>
+      </font>
+     </property>
+     <property name="text">
+      <string>Individual Motor Control</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <layout class="QGridLayout" name="gridLayout_2">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item row="2" column="1">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_4">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:NORTH.LLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:TOP.LLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="PyDMLabel" name="PyDMLabel_2">
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:BOTTOM.RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_2">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:TOP.HLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>BOTTOM</string>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="3">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_8">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:SOUTH.HLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="6">
+      <widget class="PyDMShellCommand" name="PyDMShellCommand_2">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Expert</string>
+       </property>
+       <property name="commands" stdset="0">
+        <stringlist>
+         <string>typhos &quot;pcdsdevices.epics_motor.BeckhoffAxis[{'prefix':'${prefix}:MMS:BOTTOM','name':'${name}_bottom'}]&quot;</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <widget class="PyDMLabel" name="PyDMLabel_4">
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:SOUTH.RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="4">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:NORTH.VAL</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>NORTH</string>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="4">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:TOP.VAL</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="PyDMLabel" name="PyDMLabel_3">
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:NORTH.RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="5">
+      <widget class="PyDMPushButton" name="PyDMPushButton_4">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: red;</string>
+       </property>
+       <property name="text">
+        <string>Stop</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:SOUTH.STOP</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_5">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:SOUTH.LLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="4">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:BOTTOM.VAL</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="PyDMLabel" name="PyDMLabel">
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="showUnits" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:TOP.RBV</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="4">
+      <widget class="PyDMLineEdit" name="PyDMLineEdit_4">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>80</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:SOUTH.VAL</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>TOP</string>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="6">
+      <widget class="PyDMShellCommand" name="PyDMShellCommand_3">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Expert</string>
+       </property>
+       <property name="commands" stdset="0">
+        <stringlist>
+         <string>typhos &quot;pcdsdevices.epics_motor.BeckhoffAxis[{'prefix':'${prefix}:MMS:NORTH','name':'${name}_north'}]&quot;</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_3">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:BOTTOM.LLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="6">
+      <widget class="PyDMShellCommand" name="PyDMShellCommand">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Expert</string>
+       </property>
+       <property name="showIcon" stdset="0">
+        <bool>true</bool>
+       </property>
+       <property name="commands" stdset="0">
+        <stringlist>
+         <string>typhos &quot;pcdsdevices.epics_motor.BeckhoffAxis[{'prefix':'${prefix}:MMS:TOP','name':'${name}_top'}]&quot;</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="6">
+      <widget class="PyDMShellCommand" name="PyDMShellCommand_4">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="text">
+        <string>Expert</string>
+       </property>
+       <property name="commands" stdset="0">
+        <stringlist>
+         <string>typhos &quot;pcdsdevices.epics_motor.BeckhoffAxis[{'prefix':'${prefix}:MMS:SOUTH','name':'${name}_south'}]&quot;</string>
+        </stringlist>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="5">
+      <widget class="PyDMPushButton" name="PyDMPushButton">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: red;</string>
+       </property>
+       <property name="text">
+        <string>Stop</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:TOP.STOP</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_6">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:BOTTOM.HLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>SOUTH</string>
+       </property>
+       <property name="indent">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="3">
+      <widget class="PyDMByteIndicator" name="PyDMByteIndicator_7">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:NORTH.HLS</string>
+       </property>
+       <property name="onColor" stdset="0">
+        <color>
+         <red>255</red>
+         <green>255</green>
+         <blue>0</blue>
+        </color>
+       </property>
+       <property name="showLabels" stdset="0">
+        <bool>false</bool>
+       </property>
+       <property name="circles" stdset="0">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="5">
+      <widget class="PyDMPushButton" name="PyDMPushButton_2">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: red;</string>
+       </property>
+       <property name="text">
+        <string>Stop</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:BOTTOM.STOP</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="5">
+      <widget class="PyDMPushButton" name="PyDMPushButton_3">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">background-color: red;</string>
+       </property>
+       <property name="text">
+        <string>Stop</string>
+       </property>
+       <property name="channel" stdset="0">
+        <string>ca://${prefix}:MMS:NORTH.STOP</string>
+       </property>
+       <property name="pressValue" stdset="0">
+        <string>1</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
  </widget>
  <customwidgets>
   <customwidget>


### PR DESCRIPTION
@baljamal this fixes the issue where the typhos title disappears
related to https://github.com/pcdshub/typhos/issues/634

![image](https://github.com/user-attachments/assets/471c8319-5a73-4265-8fda-0430466e15bf)
